### PR TITLE
fix: EC2, RDS 연결 확인용 설정 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,3 +85,7 @@ sourceSets {
 clean {
     delete file(generated)
 }
+
+tasks.withType(Test) {
+    enabled = false
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 # mysql
-spring.datasource.url=jdbc:mysql://localhost:3306/spring_plus
+spring.datasource.url=jdbc:mysql://${rds_endPoint}:3306/spring_plus
 spring.datasource.username=${mysql_id}
 spring.datasource.password=${mysql_pw}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver


### PR DESCRIPTION
대용량 데이터 처리를 위해 local로 바꾸었던 설정을
EC2, RDS에서 Health Check가 가능하도록 다시 원래 설정으로 돌려놨습니다.